### PR TITLE
Add INVALID_FRAMEBUFFER_OPERATION to Error

### DIFF
--- a/webgl.d.ts
+++ b/webgl.d.ts
@@ -1063,6 +1063,7 @@ declare namespace WebGLRenderingContextStrict {
 		| GL['INVALID_ENUM']
 		| GL['INVALID_VALUE']
 		| GL['INVALID_OPERATION']
+		| GL['INVALID_FRAMEBUFFER_OPERATION']
 		| GL['OUT_OF_MEMORY']
 		| GL['CONTEXT_LOST_WEBGL'];
 	type ShaderPrecisionType = GL['LOW_FLOAT']


### PR DESCRIPTION
Add a missing enum value to the Error type to allow switch-exhaustiveness-check to work properly.

Reference:
https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/getError
https://www.khronos.org/registry/OpenGL-Refpages/es2.0/xhtml/glGetError.xml